### PR TITLE
tests pass now

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ libraryDependencies ++= Seq(
   jdbc,
   cache,
   ws,
-  specs2 % Test
+  specs2 % Test,
+  "com.codeborne" % "phantomjsdriver" % "1.2.1"
 )
 
 playRunHooks <+= baseDirectory.map(Webpack.apply)
@@ -20,6 +21,12 @@ playRunHooks <+= baseDirectory.map(Webpack.apply)
 routesGenerator := InjectedRoutesGenerator
 
 excludeFilter in (Assets, JshintKeys.jshint) := "*.js"
+
+watchSources ~= { (ws: Seq[File]) =>
+  ws filterNot { path =>
+    path.getName.endsWith(".js") || path.getName == ("build")
+  }
+}
 
 pipelineStages := Seq(digest, gzip)
 

--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -24,7 +24,7 @@ class ApplicationSpec extends Specification {
 
       status(home) must equalTo(OK)
       contentType(home) must beSome.which(_ == "text/html")
-      contentAsString(home) must contain ("Your new application is ready.")
+      contentAsString(home) must contain ("Play, React JS and webpack")
     }
   }
 }

--- a/test/IntegrationSpec.scala
+++ b/test/IntegrationSpec.scala
@@ -1,9 +1,10 @@
+import org.openqa.selenium.phantomjs.PhantomJSDriver
+import org.openqa.selenium.remote.DesiredCapabilities
 import org.specs2.mutable._
 import org.specs2.runner._
 import org.junit.runner._
 
 import play.api.test._
-import play.api.test.Helpers._
 
 /**
  * add your integration spec here.
@@ -16,9 +17,15 @@ class IntegrationSpec extends Specification {
 
     "work from within a browser" in new WithBrowser {
 
+      override val webDriver = {
+        val capabilities = new DesiredCapabilities()
+        capabilities.setJavascriptEnabled(true)
+        new PhantomJSDriver(capabilities)
+      }
+
       browser.goTo("http://localhost:" + port)
 
-      browser.pageSource must contain("Your new application is ready.")
+      browser.pageSource must contain("Ninja")
     }
   }
 }

--- a/webpack.sbt
+++ b/webpack.sbt
@@ -1,4 +1,4 @@
-lazy val webpack = taskKey[Unit]("Run webpack when packaging the application")
+lazy val webpack = TaskKey[Unit]("Run webpack when packaging the application")
 
 def runWebpack(file: File) = {
   Process("webpack", file) !
@@ -11,3 +11,5 @@ webpack := {
 dist <<= dist dependsOn webpack
 
 stage <<= stage dependsOn webpack
+
+test <<= (test in Test) dependsOn webpack


### PR DESCRIPTION
Hello, 
I'm very grateful to you for you work on play and webpack integration, it really saved me a lot of time. 
But tests in you repo don't work. The most interesting part here is that function tests don't work mostly because of  htmlunit is unable to evaluate such a complex javascript. 
So i tweaked them a little bit and now functional tests use phantomjs and pass successfully if you have phantomjs installed ;).
Also webpack reassembles js before running tests ( so you can do some modify-test-modify stuff ) and sources generated by webpack are excluded from watchSource ( so ~test & ~compile should work properly also).
I'm not a confident scala-developer by any means so I'm not sure about all that complex sbt stuff, but i really want to save someone's time by at least pointing them in some general direction with functional testing with webpack and play.
Please, consider my commits for merge.
Thank you.
